### PR TITLE
Remove debugger call when setting CQL version

### DIFF
--- a/vendor/1.2/gen-rb/cassandra.rb
+++ b/vendor/1.2/gen-rb/cassandra.rb
@@ -711,7 +711,6 @@ module CassandraCQL
       end
 
       def send_set_cql_version(version)
-        debugger
         send_message('set_cql_version', Set_cql_version_args, :version => version)
       end
 


### PR DESCRIPTION
When passing :cql_version to CassandraCQL::Database.new, undefined method for 'debugger' was raised.
