### PR TITLE
Set consistency level with CQL3

### DIFF
--- a/lib/cassandra-cql/database.rb
+++ b/lib/cassandra-cql/database.rb
@@ -39,8 +39,7 @@ module CassandraCQL
         CassandraCQL::Thrift::Client.method_defined?(:execute_cql3_query)
 
       if @use_cql3_query
-        @cql3_consistency_level =
-          @options[:consistency_level] || CassandraCQL::Thrift::ConsistencyLevel::QUORUM
+        self.consistency = @options[:consistency] || :quorum
       end
 
       @servers = servers
@@ -106,7 +105,7 @@ module CassandraCQL
 
     def execute_cql_query(cql, compression=CassandraCQL::Thrift::Compression::NONE)
       if @use_cql3_query
-        @connection.execute_cql3_query(cql, compression, @cql3_consistency_level) #TODO consistency level
+        @connection.execute_cql3_query(cql, compression, consistency)
       else
         @connection.execute_cql_query(cql, compression)
       end
@@ -136,6 +135,27 @@ module CassandraCQL
       # @auth_request after the first successful login.
       @auth_request = request
       ret
+    end
+
+    def consistency
+      @consistency ||= get_consistency(:quorum)
+    end
+
+    def consistency=(level)
+      @consistency_name = level
+      @consistency = get_consistency(level)
+    end
+
+    private
+
+    def get_consistency(level)
+      level_const = level.to_s.upcase
+
+      if CassandraCQL::Thrift::ConsistencyLevel.const_defined?(level_const)
+        CassandraCQL::Thrift::ConsistencyLevel.const_get(level_const)
+      else
+        raise ArgumentError.new("Invalid consistency level")
+      end
     end
   end
 end

--- a/lib/cassandra-cql/database.rb
+++ b/lib/cassandra-cql/database.rb
@@ -137,6 +137,13 @@ module CassandraCQL
       ret
     end
 
+    def with_consistency(level)
+      previous_level = @consistency_name
+      self.consistency = level
+      yield
+      self.consistency = previous_level
+    end
+
     def consistency
       @consistency ||= get_consistency(:quorum)
     end

--- a/spec/database_spec.rb
+++ b/spec/database_spec.rb
@@ -34,6 +34,14 @@ describe "Database" do
         @connection.consistency.should == CassandraCQL::Thrift::ConsistencyLevel::ALL
       end
 
+      it "should change the consistency within a block" do
+        @connection.with_consistency(:one) do
+          @connection.consistency.should == CassandraCQL::Thrift::ConsistencyLevel::ONE
+        end
+
+        @connection.consistency.should == CassandraCQL::Thrift::ConsistencyLevel::QUORUM
+      end
+
       it "should raise and error if invalid consistency is used" do
         expect { @connection.consistency = :foo }.to raise_error(ArgumentError)
       end

--- a/spec/database_spec.rb
+++ b/spec/database_spec.rb
@@ -5,14 +5,14 @@ describe "Database" do
   before do
     @connection = setup_cassandra_connection
   end
-  
+
   describe "reset!" do
     it "should create a new connection" do
       @connection.should_receive(:connect!)
       @connection.reset!
     end
   end
-  
+
   describe "login!" do
     it "should call login! on connection" do
       creds = { 'username' => 'myuser', 'password' => 'mypass' }
@@ -20,6 +20,23 @@ describe "Database" do
         auth.credentials.should eq(creds)
       end
       @connection.login!(creds['username'], creds['password'])
+    end
+  end
+
+  describe "setting the consistency level" do
+    context "with CQL3", :cql_version => "3.0.0" do
+      it "should return the current consistency" do
+        @connection.consistency.should == CassandraCQL::Thrift::ConsistencyLevel::QUORUM
+      end
+
+      it "should change the consistency" do
+        @connection.consistency = :all
+        @connection.consistency.should == CassandraCQL::Thrift::ConsistencyLevel::ALL
+      end
+
+      it "should raise and error if invalid consistency is used" do
+        expect { @connection.consistency = :foo }.to raise_error(ArgumentError)
+      end
     end
   end
 end


### PR DESCRIPTION
Manage the consistency level on queries per connection, and temporarily change it within a block.
